### PR TITLE
Re-establish pypi publishing workflows

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -9,8 +9,7 @@ name: Publish to PyPI
 on:
   release:
     types:
-      - published    # covers both full releases and prereleases; jobs below
-      - prereleased  # filter individually with `if:` conditions
+      - published    # fires for both full releases and prereleases; job-level `if:` conditions route accordingly
 
 jobs:
   # ── Step 1: build the sdist + wheel ─────────────────────────────────────────

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,86 @@
+name: Publish to PyPI
+
+# Triggers:
+#   - GitHub Release published (not a prerelease) → publishes to real PyPI
+#   - GitHub Release marked as prerelease       → publishes to TestPyPI only
+#
+# Version is derived automatically from the git tag via poetry-dynamic-versioning.
+# The `version` field in pyproject.toml is a placeholder and does not need to be updated.
+on:
+  release:
+    types:
+      - published    # covers both full releases and prereleases; jobs below
+      - prereleased  # filter individually with `if:` conditions
+
+jobs:
+  # ── Step 1: build the sdist + wheel ─────────────────────────────────────────
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history required for poetry-dynamic-versioning to read tags
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install build frontend
+        run: python3 -m pip install build poetry-dynamic-versioning --user
+
+      - name: Build wheel and source tarball
+        run: python3 -m build
+
+      - name: Upload built distributions as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  # ── Step 2a: publish full releases to PyPI ──────────────────────────────────
+  publish-to-pypi:
+    name: Publish to PyPI
+    # Only run for non-prerelease GitHub Releases
+    if: "!github.event.release.prerelease"
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/snakemake-executor-plugin-htcondor
+    permissions:
+      id-token: write  # required for OIDC trusted publishing
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  # ── Step 2b: publish prereleases to TestPyPI ────────────────────────────────
+  publish-to-testpypi:
+    name: Publish to TestPyPI
+    # Only run for prerelease GitHub Releases
+    if: github.event.release.prerelease
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/snakemake-executor-plugin-htcondor
+    permissions:
+      id-token: write  # required for OIDC trusted publishing
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,44 @@
+name: Create prerelease on tag
+
+# When a vX.Y.Z tag is pushed, automatically create a GitHub prerelease.
+# This triggers the `prereleased` event in pypi-publish.yml → TestPyPI.
+# To publish to real PyPI, go to the Releases page and mark it as a full release,
+# which fires the `published` event in pypi-publish.yml → PyPI.
+#
+# The tag filter is a two-layer check:
+#   1. Glob (GitHub): requires vN.N.N* shape, rejecting tags like `vabc` or `v1`
+#   2. Regex (job step): enforces full PEP 440 compliance before anything is created
+on:
+  push:
+    tags:
+      - 'v[0-9]*.[0-9]*.[0-9]*'
+
+jobs:
+  create-prerelease:
+    name: Create GitHub prerelease
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Validate tag is a PEP 440 version
+        run: |
+          python3 -c "
+          import re, sys
+          tag = '${{ github.ref_name }}'
+          version = tag.lstrip('v')
+          pattern = r'^(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*)){2}((a|b|rc)(0|[1-9][0-9]*))?(\.(post|dev)(0|[1-9][0-9]*))*$'
+          if not re.fullmatch(pattern, version):
+              print(f'ERROR: {tag!r} is not a valid PEP 440 version tag')
+              sys.exit(1)
+          print(f'{tag!r} is a valid PEP 440 version tag')
+          "
+
+      - name: Create prerelease from tag
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --prerelease \
+            --generate-notes \
+            --title "${{ github.ref_name }}"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -7,7 +7,7 @@ name: Create prerelease on tag
 #
 # The tag filter is a two-layer check:
 #   1. Glob (GitHub): requires vN.N.N* shape, rejecting tags like `vabc` or `v1`
-#   2. Regex (job step): enforces full PEP 440 compliance before anything is created
+#   2. Regex (job step): enforces a strict subset of PEP 440 (vN.N.N with optional pre/post/dev) before anything is created
 on:
   push:
     tags:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,15 @@
 [build-system]
-requires = [ "poetry-core",]
-build-backend = "poetry.core.masonry.api"
+requires = [ "poetry-core", "poetry-dynamic-versioning>=1.0.0,<2.0.0",]
+build-backend = "poetry-dynamic-versioning.backend"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "pep440"
 
 [tool.poetry]
 name = "snakemake-executor-plugin-htcondor"
-version = "0.2.0"
+version = "0.0.0"
 description = "A Snakemake executor plugin for submitting jobs to an HTCondor cluster."
 authors = [ "Jannis Speer <jannis.speer@tutanota.com>", "Justin Hiemstra <jhiemstra@wisc.edu>",]
 readme = "README.md"


### PR DESCRIPTION
This re-establishes a pypi publishing workflow, which now becomes:
1. When ready to start a new release, create a version tag, e.g. `v1.2.3` and push to the repo (note that tags should follow PEP 440, but contain a preceding `v`)
2. The `tag-release.yml` action will generate a pre-release page and trigger publication to `test.pypi.org`
3. Verify the release looks correct on TestPyPI (metadata, version number, installability).
4. When satisfied, the pre-release can be marked as a full release through GitHub's UI --> this will trigger publication to regular pypi.

This also has the side effect of moving version info out of the pyproject.toml and into dynamic versioning supplied by git tags.