### PR TITLE
Separate unit tests from integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: su -c "poetry install" submituser
 
       - name: Run pytest
-        run: su -c "poetry run coverage run -m pytest tests/ -vvv" submituser
+        run: su -c "poetry run coverage run -m pytest tests/ integration_tests/ -vvv" submituser
 
       - name: Check HTCondor logs
         run: |

--- a/integration_tests/test_workflows.py
+++ b/integration_tests/test_workflows.py
@@ -1,4 +1,5 @@
 from typing import Optional, Mapping
+import pytest
 import snakemake.common.tests
 from snakemake_interface_executor_plugins.settings import ExecutorSettingsBase
 from snakemake_interface_common.plugin_registry.plugin import TaggedSettings
@@ -7,6 +8,7 @@ from snakemake_executor_plugin_htcondor import ExecutorSettings
 
 # Check out the base classes found here for all possible options and methods:
 # https://github.com/snakemake/snakemake/blob/main/snakemake/common/tests/__init__.py
+@pytest.mark.integration
 class TestWorkflowsBase(snakemake.common.tests.TestWorkflowsBase):
     __test__ = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ snakemake-interface-common = "^1.17.1"
 snakemake-interface-executor-plugins = "^9.0.0"
 htcondor = "^24.5.1"
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = ["integration: requires a running HTCondor AP (submits real jobs)"]
+
 [tool.poetry.group.dev.dependencies]
 black = "^24.2.0"
 flake8 = "^7.0.0"


### PR DESCRIPTION
This prevents a raw invocation of `pytest` from submitting jobs when run on a real AP