### PR TITLE
Add support for output/error streaming, but warn of consequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,19 @@ For the official documentation, visit [Snakemake plugin catalog](https://snakema
 - **HTCondor Resource Field Units**: Fields that accept size units (such as `request_memory` and `request_disk`) support suffixes K, M, G, or T (optionally followed by B). These units are based on powers of 1024, so each step is 1024 times larger than the previous one (e.g., 1K = 1024 bytes, 1M = 1024 × 1024 bytes, 1G = 1024 × 1024 × 1024 bytes).
 
 The following [submit description file commands](https://htcondor.readthedocs.io/en/latest/man-pages/condor_submit.html) are supported (add them as user-defined resources):
-| Basic                              | Matchmaking      | Matchmaking (GPU)         | Policy                     |
-| ---------------------------------- | ---------------- | ------------------------- | -------------------------- |
-| `getenv`                           | `rank`           | `request_gpus`            | `max_retries`              |
-| `environment`                      | `request_disk`   | `require_gpus`            | `allowed_execute_duration` |
-| `input`                            | `request_memory` | `gpus_minimum_capability` | `allowed_job_duration`     |
-| `max_materialize`                  | `requirements`   | `gpus_minimum_memory`     | `retry_until`              |
-| `max_idle`                         | `classad_<foo>`**| `gpus_minimum_runtime`    |                            |
-| `job_wrapper`*                     |                  | `cuda_version`            |                            |
-| `universe`                         |                  |                           |                            |
-| `htcondor_transfer_input_files`*** |                  |                           |                            |
-| `htcondor_transfer_output_files`***|                  |                           |                            |
+| Basic                               | Matchmaking      | Matchmaking (GPU)         | Policy                     |
+| ----------------------------------  | ---------------- | ------------------------- | -------------------------- |
+| `getenv`                            | `rank`           | `request_gpus`            | `max_retries`              |
+| `environment`                       | `request_disk`   | `require_gpus`            | `allowed_execute_duration` |
+| `input`                             | `request_memory` | `gpus_minimum_capability` | `allowed_job_duration`     |
+| `max_materialize`                   | `requirements`   | `gpus_minimum_memory`     | `retry_until`              |
+| `max_idle`                          | `classad_<foo>`**| `gpus_minimum_runtime`    |                            |
+| `job_wrapper`*                      |                  | `cuda_version`            |                            |
+| `universe`                          |                  |                           |                            |
+| `stream_output`***                  |                  |                           |                            |
+| `stream_error`***                   |                  |                           |                            |
+| `htcondor_transfer_input_files`**** |                  |                           |                            |
+| `htcondor_transfer_output_files`****|                  |                           |                            |
 
 Additionally, the following **executor-specific resources** are available with explicit units (see [Resources with Explicit Units](#resources-with-explicit-units) below):
 | Resource                      | Description                           | Equivalent HTCondor Command |
@@ -55,7 +57,13 @@ snakemake "$@"
 \*\* Custom ClassAds can be defined using the `classad_` prefix as a custom job resource. For example, to define the ClassAd `+MyClassAd`, define `classad_MyClassAd` in
 the job's resources.
 
-\*\*\* Additional input or output files for transfer can be specified using `htcondor_transfer_input_files` and `htcondor_transfer_output_files` resources.
+\*\*\* For testing or debugging one or two jobs **at a time**. Do **not** use for many simultaneous jobs!
+Streaming the job's standard out and standard error may be useful to monitor a job's progress while it runs on the execution point.
+However, **be aware** that for high-concurrency/high-throughput workflows, this streaming can be very costly and may be detrimental not only to your own jobs, but to the entire shared computing resource.
+Misusing these attributes is a good way to catch your system administrator's attention and have your HTCondor access blocked!
+If you feel the need to stream standard out and standard error to monitor jobs for potential bugs, do this only on a small testing subset of your final workflow and _not_ on large runs.
+
+\*\*\*\* Additional input or output files for transfer can be specified using `htcondor_transfer_input_files` and `htcondor_transfer_output_files` resources.
 These are useful for transferring files that aren't part of the rule's `input:`/`output:` directives (e.g., helper scripts, configuration files, logs, intermediate results).
 Supports both string (comma-separated) and list formats. Wildcards (e.g., `{sample}`) are expanded for individual jobs, but **not** for grouped jobs since the resources are defined at the group level.
 Files on shared filesystem prefixes are automatically excluded from transfer.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ snakemake "$@"
 \*\* Custom ClassAds can be defined using the `classad_` prefix as a custom job resource. For example, to define the ClassAd `+MyClassAd`, define `classad_MyClassAd` in
 the job's resources.
 
-\*\*\* For testing or debugging one or two jobs **at a time**. Do **not** use for many simultaneous jobs!
+\*\*\* `stream_output` and `stream_error` are for testing or debugging one or two jobs **at a time**. Do **not** use for many simultaneous jobs!
 Streaming the job's standard out and standard error may be useful to monitor a job's progress while it runs on the execution point.
 However, **be aware** that for high-concurrency/high-throughput workflows, this streaming can be very costly and may be detrimental not only to your own jobs, but to the entire shared computing resource.
 Misusing these attributes is a good way to catch your system administrator's attention and have your HTCondor access blocked!

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import List, AsyncGenerator, Optional, Dict
+from typing import List, Any, AsyncGenerator, Optional, Dict, Callable
 import time
 from snakemake_interface_executor_plugins.executors.base import SubmittedJobInfo
 from snakemake_interface_executor_plugins.executors.remote import RemoteExecutor
@@ -20,6 +20,8 @@ from os.path import join, isabs, relpath, normpath, exists
 from os import makedirs, sep
 import re
 import sys
+
+LogSpec = tuple[Callable[[str], None], str]
 
 
 class JobStatus(Enum):
@@ -1063,8 +1065,13 @@ class Executor(RemoteExecutor):
         )
 
     def _set_resources(
-        self, submit_dict: dict, job: JobExecutorInterface, key: str, default=None
-    ):
+        self,
+        submit_dict: dict[str, Any],
+        job: JobExecutorInterface,
+        key: str,
+        default: Any = None,
+        logger: Optional[LogSpec] = None,
+    ) -> None:
         """
         Set submit_dict[key] from the job resources so that false values are correctly handled
 
@@ -1073,11 +1080,17 @@ class Executor(RemoteExecutor):
             job: The Snakemake job being prepared for submission
             key: The resource attribute name to extract and set
             default: Value to use if resource is not defined
+            logger: Optional tuple of (logger_method, message)
 
         """
         value = job.resources.get(key)
         if value is not None:
             submit_dict[key] = value
+
+            if logger is not None and value != default:
+                logger_method, message = logger
+                logger_method(message)
+
         elif default is not None:
             submit_dict[key] = default
 
@@ -1171,8 +1184,27 @@ class Executor(RemoteExecutor):
 
         # Basic commands
         self._set_resources(submit_dict, job, "getenv", default=False)
-
         self._set_resources(submit_dict, job, "preserve_relative_paths", default=True)
+        self._set_resources(
+            submit_dict,
+            job,
+            "stream_output",
+            logger=(
+                self.logger.warning,
+                "Setting HTCondor stream_output may significantly impact performance "
+                "in high-throughput workflows.",
+            ),
+        )
+        self._set_resources(
+            submit_dict,
+            job,
+            "stream_error",
+            logger=(
+                self.logger.warning,
+                "Setting HTCondor stream_error may significantly impact performance "
+                "in high-throughput workflows.",
+            ),
+        )
 
         # Build the HTCondor environment string by merging:
         #   1. Snakemake-managed env vars (storage plugin tokens, etc.) from self.envvars()


### PR DESCRIPTION
Several users have asked for the ability to stream stdout/stderr from their running jobs while the workflow is ongoing. Previously I thought this would require some convoluted `condor_chirp` setup, but it turns out there are first-class submit attributes for it, making this super simple for us to do!

The one caveat that I try to hammer home in both a logged warning and in the docs is that this is **not** recommended for truly high-throughput workflows because everyone trying to stream a billion files will probably have detrimental consequences on the AP.

The warning text was workshopped with a CHTC facilitator and is intentionally scary.

Closes #28 