### PR TITLE
feature/allow submission of raw and site-specific attributes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Install Python and more yum
         run: |
+          yum install -y sqlite sqlite-devel
           yum install -y python${{ env.PYTHON_VERSION }}
           yum install -y python${{ env.PYTHON_VERSION }}-pip
           yum install -y python${{ env.PYTHON_VERSION }}-devel

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ snakemake "$@"
 \*\* Custom ClassAds can be defined using the `classad_` prefix as a custom job resource. For example, to define the ClassAd `+MyClassAd`, define `classad_MyClassAd` in
 the job's resources.
 
+\*\* The plugin also supports the `htcondor_submit_` resource prefix to pass
+raw HTCondor submit attributes through to the submit description (set per-rule
+in the `Snakefile` or in a profile). For example:
+- `htcondor_submit_output_destination` -> `output_destination`
+- `htcondor_submit_MY__SendCredential` -> `MY.SendCredential` (use double underscore to represent `.`)
+
+Behavior mirrors `classad_`: string values are quoted; non-string values (ints, bools) are passed through unchanged.
+lists and dicts may not serialize to valid HTCondor submit/ClassAd values.
+Consider validation or serialization if you plan to use complex types.
+
 \*\*\* Additional input or output files for transfer can be specified using `htcondor_transfer_input_files` and `htcondor_transfer_output_files` resources.
 These are useful for transferring files that aren't part of the rule's `input:`/`output:` directives (e.g., helper scripts, configuration files, logs, intermediate results).
 Supports both string (comma-separated) and list formats. Wildcards (e.g., `{sample}`) are expanded for individual jobs, but **not** for grouped jobs since the resources are defined at the group level.

--- a/README.md
+++ b/README.md
@@ -55,17 +55,18 @@ snakemake "$@"
 \*\* Custom ClassAds can be defined using the `classad_` prefix as a custom job resource. For example, to define the ClassAd `+MyClassAd`, define `classad_MyClassAd` in
 the job's resources.
 
-\*\* The plugin also supports the `htcondor_submit_` resource prefix to pass
+** The plugin also supports the `htcondor_submit_` resource prefix to pass
 raw HTCondor submit attributes through to the submit description (set per-rule
 in the `Snakefile` or in a profile). For example:
 - `htcondor_submit_output_destination` -> `output_destination`
 - `htcondor_submit_MY__SendCredential` -> `MY.SendCredential` (use double underscore to represent `.`)
 
-Behavior mirrors `classad_`: string values are quoted; non-string values (ints, bools) are passed through unchanged.
-lists and dicts may not serialize to valid HTCondor submit/ClassAd values.
-Consider validation or serialization if you plan to use complex types.
+Behavior mirrors `classad_`: string values are quoted; non-string values (ints, bools) are passed through unchanged. Use only strings, ints, or bools.
 
-\*\*\* Additional input or output files for transfer can be specified using `htcondor_transfer_input_files` and `htcondor_transfer_output_files` resources.
+If you define `htcondor_submit_<name>` where `<name>` corresponds to any of the supported fields listed in the tables above, that `htcondor_submit_` entry will be ignored.
+In those cases, set the resource directly (for example `request_memory` or `htcondor_transfer_input_files`) instead of using `htcondor_submit_*`.
+
+\*\*\* Input or output files for transfer can be specified using `htcondor_transfer_input_files` and `htcondor_transfer_output_files` resources.
 These are useful for transferring files that aren't part of the rule's `input:`/`output:` directives (e.g., helper scripts, configuration files, logs, intermediate results).
 Supports both string (comma-separated) and list formats. Wildcards (e.g., `{sample}`) are expanded for individual jobs, but **not** for grouped jobs since the resources are defined at the group level.
 Files on shared filesystem prefixes are automatically excluded from transfer.

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -1243,15 +1243,20 @@ class Executor(RemoteExecutor):
                     submit_dict[classad_key] = f'"{value}"'
                 else:
                     submit_dict[classad_key] = value
-            if key.startswith("htcondor_submit_"):
+            elif key.startswith("htcondor_submit_"):
                 raw_attri = key.removeprefix("htcondor_submit_")
-                # Replace underscore with dot to unescape
+                # Replace double underscore with dot to unescape
                 attri_name = raw_attri.replace("__", ".")
                 value = job.resources.get(key)
-                if isinstance(value, str):
-                    submit_dict[attri_name] = f'"{value}"'  # string literal
+                val = f'"{value}"' if isinstance(value, str) else value
+                # Raw htcondor_submit_* attributes should not override
+                # values the executor already set.
+                if attri_name in submit_dict:
+                    self.logger.debug(
+                        f"Skipping htcondor_submit_{raw_attri} override of {attri_name}"
+                    )
                 else:
-                    submit_dict[attri_name] = value
+                    submit_dict[attri_name] = val
 
         # Log resource requests with human-readable units
         self._log_resource_requests(submit_dict)

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -1233,7 +1233,7 @@ class Executor(RemoteExecutor):
         # Name the jobs in the queue something that tells us what the job is
         submit_dict["batch_name"] = batch_name
 
-        # Check any custom classads
+        # Check any custom classads and raw attributes passed with the resource prefix
         for key in job.resources.keys():
             if key.startswith("classad_"):
                 classad_key = "+" + key.removeprefix("classad_")
@@ -1243,6 +1243,15 @@ class Executor(RemoteExecutor):
                     submit_dict[classad_key] = f'"{value}"'
                 else:
                     submit_dict[classad_key] = value
+            if key.startswith("htcondor_submit_"):
+                raw_attri = key.removeprefix("htcondor_submit_")
+                # Replace underscore with dot to unescape
+                attri_name = raw_attri.replace("__", ".")
+                value = job.resources.get(key)
+                if isinstance(value, str):
+                    submit_dict[attri_name] = f'"{value}"'  # string literal
+                else:
+                    submit_dict[attri_name] = value
 
         # Log resource requests with human-readable units
         self._log_resource_requests(submit_dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,10 @@
 Shared test fixtures and utilities for HTCondor executor tests.
 """
 
-from unittest.mock import Mock
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
+
+import snakemake_executor_plugin_htcondor as plugin
 from snakemake_executor_plugin_htcondor import Executor
 
 
@@ -34,6 +37,54 @@ def create_mock_executor(shared_fs_prefixes=None):
     executor._parse_file_list = Executor._parse_file_list.__get__(executor, Executor)
 
     return executor
+
+
+def create_mock_submit_executor(tmp_path):
+    """Create a mock executor configured for run_job submit tests."""
+    executor = create_mock_executor()
+    executor.jobDir = str(tmp_path / "jobs")
+    executor.workflow = Mock()
+    executor.workflow.storage_settings.shared_fs_usage = False
+    executor.workflow.executor_settings = Mock()
+    executor.workflow.executor_settings.output_destination = None
+    executor.envvars = Mock(return_value={})
+    executor.report_job_submission = Mock()
+    executor._unified_log_file = str(tmp_path / "snakemake-rules.log")
+
+    executor.run_job = Executor.run_job.__get__(executor, Executor)
+    executor._set_resources = Executor._set_resources.__get__(executor, Executor)
+
+    executor._get_exec_args_and_transfer_files = Mock(
+        return_value=("python", "-m snakemake --cores 1", [], [], [])
+    )
+    executor._handle_explicit_unit_resources = Mock()
+    executor._log_resource_requests = Mock()
+    return executor
+
+
+@contextmanager
+def mock_htcondor_submission(captured_submit_dict):
+    """Patch HTCondor submission objects and capture the submit dict."""
+
+    class FakeSubmitResult:
+        def cluster(self):
+            return 12345
+
+    class FakeSubmit:
+        def __init__(self, submit_dict):
+            captured_submit_dict.update(submit_dict)
+
+        def issue_credentials(self):
+            return None
+
+    class FakeSchedd:
+        def submit(self, submit_description):
+            return FakeSubmitResult()
+
+    with patch.object(plugin.htcondor, "Submit", FakeSubmit), patch.object(
+        plugin.htcondor, "Schedd", FakeSchedd
+    ):
+        yield
 
 
 def create_mock_individual_job(

--- a/tests/test_submit_attributes.py
+++ b/tests/test_submit_attributes.py
@@ -1,0 +1,215 @@
+"""
+Tests for HTCondor submit attribute handling.
+
+Raw attributes are passed via the htcondor_submit_<name> resource prefix:
+    htcondor_submit_output_destination -> output_destination (string)
+    htcondor_submit_MY__SendCredential -> My.SendCredential (double underscore converts to dot)
+    htcondor_submit_nice_user          -> nice_user (boolean)
+    htcondor_submit_priority           -> priority (integer)
+
+String values are wrapped in double quotes (for ClassAd string literals).
+Non-string values (bool, int) are passed through as-is.
+
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+
+import snakemake_executor_plugin_htcondor as plugin
+from snakemake_executor_plugin_htcondor import Executor
+
+from conftest import create_mock_executor
+
+
+class FakeSubmitResult:
+    """Minimal fake HTCondor submit result that exposes a cluster id."""
+
+    def cluster(self):
+        return 12345
+
+
+def make_fake_submit(captured_submit_dict):
+    """Build a fake htcondor.Submit class that captures the submit dict."""
+
+    class FakeSubmit:
+        """Capture submit_dict passed to htcondor.Submit and satisfy run_job."""
+
+        def __init__(self, submit_dict):
+            captured_submit_dict.update(submit_dict)
+
+        def issue_credentials(self):
+            return None
+
+    return FakeSubmit
+
+
+class FakeSchedd:
+    """Minimal fake HTCondor schedd that returns a submit result."""
+
+    def submit(self, submit_description):
+        return FakeSubmitResult()
+
+
+class TestSubmittingAttributes:
+    """Tests for HTCondor raw and ClassAd submit attribute handling."""
+
+    @pytest.fixture
+    def mock_executor(self, tmp_path):
+        """Create a mock executor with minimal setup"""
+        executor = create_mock_executor()
+        executor.jobDir = str(tmp_path / "jobs")
+        executor.workflow = Mock()
+        executor.workflow.storage_settings.shared_fs_usage = False
+        executor.workflow.executor_settings = Mock()
+        executor.workflow.executor_settings.output_destination = None
+        executor.envvars = Mock(return_value={})
+        executor.report_job_submission = Mock()
+        executor._unified_log_file = str(tmp_path / "snakemake-rules.log")
+        # Bind real method under test + helper used by run_job
+        executor.run_job = Executor.run_job.__get__(executor, Executor)
+        executor._set_resources = Executor._set_resources.__get__(executor, Executor)
+
+        # Stub unrelated heavy pieces
+        executor._get_exec_args_and_transfer_files = Mock(
+            return_value=("python", "-m snakemake --cores 1", [], [], [])
+        )
+        executor._handle_explicit_unit_resources = Mock()
+        executor._log_resource_requests = Mock()
+        return executor
+
+    def test_run_job_applies_htcondor_submit_raw_attributes(self, mock_executor):
+        """Test that htcondor_submit_* resources are copied into the submit dict."""
+        captured_submit_dict = {}
+        patcher_submit = patch.object(
+            plugin.htcondor, "Submit", make_fake_submit(captured_submit_dict)
+        )
+        patcher_schedd = patch.object(plugin.htcondor, "Schedd", FakeSchedd)
+        patcher_submit.start()
+        patcher_schedd.start()
+
+        try:
+            job = Mock()
+            job.name = "rule_a"
+            job.jobid = 7
+            job.threads = 1
+            job.resources = {
+                "htcondor_submit_output_destination": "/mnt/gdrive/outputs",
+                "htcondor_submit_MY__SendCredential": True,
+                "htcondor_submit_priority": 5,
+                "htcondor_submit_nice_user": True,
+            }
+
+            mock_executor.run_job(job)
+
+            assert captured_submit_dict["output_destination"] == '"/mnt/gdrive/outputs"'
+            assert captured_submit_dict["MY.SendCredential"] is True
+            assert captured_submit_dict["priority"] == 5
+            assert captured_submit_dict["nice_user"] is True
+            assert captured_submit_dict["batch_name"] == "rule_a-7"
+        finally:
+            patcher_submit.stop()
+            patcher_schedd.stop()
+
+    def test_run_job_applies_classad_attributes(self, mock_executor):
+        """Test that classad_* resources are copied into the submit dict."""
+        captured_submit_dict = {}
+
+        patcher_submit = patch.object(
+            plugin.htcondor, "Submit", make_fake_submit(captured_submit_dict)
+        )
+        patcher_schedd = patch.object(plugin.htcondor, "Schedd", FakeSchedd)
+        patcher_submit.start()
+        patcher_schedd.start()
+
+        try:
+            job = Mock()
+            job.name = "rule_b"
+            job.jobid = 8
+            job.threads = 1
+            job.resources = {
+                "classad_MyDataSource": "https://example.com/data",
+                "classad_nice_user": True,
+                "classad_priority": 5,
+            }
+
+            mock_executor.run_job(job)
+
+            assert captured_submit_dict["+MyDataSource"] == '"https://example.com/data"'
+            assert captured_submit_dict["+nice_user"] is True
+            assert captured_submit_dict["+priority"] == 5
+            assert captured_submit_dict["batch_name"] == "rule_b-8"
+        finally:
+            patcher_submit.stop()
+            patcher_schedd.stop()
+
+    def test_run_job_applies_classad_and_htcondor_submit_together(self, mock_executor):
+        """Test that classad_* and htcondor_submit_* resources can coexist."""
+        captured_submit_dict = {}
+        patcher_submit = patch.object(
+            plugin.htcondor, "Submit", make_fake_submit(captured_submit_dict)
+        )
+        patcher_schedd = patch.object(plugin.htcondor, "Schedd", FakeSchedd)
+        patcher_submit.start()
+        patcher_schedd.start()
+
+        try:
+            job = Mock()
+            job.name = "rule_c"
+            job.jobid = 9
+            job.threads = 1
+            job.resources = {
+                "classad_MyDataSource": "https://example.com/data",
+                "classad_priority": 5,
+                "htcondor_submit_nice_user": True,
+                "htcondor_submit_MY__SendCredential": False,
+            }
+
+            mock_executor.run_job(job)
+
+            assert captured_submit_dict["+MyDataSource"] == '"https://example.com/data"'
+            assert captured_submit_dict["+priority"] == 5
+            assert captured_submit_dict["nice_user"] is True
+            assert captured_submit_dict["MY.SendCredential"] is False
+            assert captured_submit_dict["batch_name"] == "rule_c-9"
+        finally:
+            patcher_submit.stop()
+            patcher_schedd.stop()
+
+    def test_run_job_passes_through_list_and_dict_values(self, mock_executor):
+        """Lists and dicts (non-string types) are passed through unchanged."""
+        # Note: the production code currently passes non-string values
+        # (including lists and dicts) through unchanged into the submit
+        # description.
+        # We can implement stricter validation or serialization methods if required.
+        captured_submit_dict = {}
+        patcher_submit = patch.object(
+            plugin.htcondor, "Submit", make_fake_submit(captured_submit_dict)
+        )
+        patcher_schedd = patch.object(plugin.htcondor, "Schedd", FakeSchedd)
+        patcher_submit.start()
+        patcher_schedd.start()
+
+        try:
+            job = Mock()
+            job.name = "rule_d"
+            job.jobid = 10
+            job.threads = 1
+            job.resources = {
+                # htcondor_submit_ keys
+                "htcondor_submit_tags": ["a", "b"],
+                "htcondor_submit_metadata": {"k": "v"},
+                # classad_ keys
+                "classad_ListAttr": [1, 2, 3],
+                "classad_MapAttr": {"x": True},
+            }
+
+            mock_executor.run_job(job)
+
+            assert captured_submit_dict["tags"] == ["a", "b"]
+            assert captured_submit_dict["metadata"] == {"k": "v"}
+            assert captured_submit_dict["+ListAttr"] == [1, 2, 3]
+            assert captured_submit_dict["+MapAttr"] == {"x": True}
+            assert captured_submit_dict["batch_name"] == "rule_d-10"
+        finally:
+            patcher_submit.stop()
+            patcher_schedd.stop()

--- a/tests/test_submit_attributes.py
+++ b/tests/test_submit_attributes.py
@@ -3,9 +3,13 @@ Tests for HTCondor submit attribute handling.
 
 Raw attributes are passed via the htcondor_submit_<name> resource prefix:
     htcondor_submit_output_destination -> output_destination (string)
-    htcondor_submit_MY__SendCredential -> My.SendCredential (double underscore converts to dot)
+    htcondor_submit_MY__SendCredential -> MY.SendCredential (double underscore converts to dot)
     htcondor_submit_nice_user          -> nice_user (boolean)
     htcondor_submit_priority           -> priority (integer)
+
+If a htcondor_submit_* name collides with a key the plugin already sets,
+the executor-set key takes precedence; htcondor_submit_* will not override
+built-in submit fields.
 
 String values are wrapped in double quotes (for ClassAd string literals).
 Non-string values (bool, int) are passed through as-is.
@@ -13,81 +17,20 @@ Non-string values (bool, int) are passed through as-is.
 """
 
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
-import snakemake_executor_plugin_htcondor as plugin
-from snakemake_executor_plugin_htcondor import Executor
-
-from conftest import create_mock_executor
-
-
-class FakeSubmitResult:
-    """Minimal fake HTCondor submit result that exposes a cluster id."""
-
-    def cluster(self):
-        return 12345
-
-
-def make_fake_submit(captured_submit_dict):
-    """Build a fake htcondor.Submit class that captures the submit dict."""
-
-    class FakeSubmit:
-        """Capture submit_dict passed to htcondor.Submit and satisfy run_job."""
-
-        def __init__(self, submit_dict):
-            captured_submit_dict.update(submit_dict)
-
-        def issue_credentials(self):
-            return None
-
-    return FakeSubmit
-
-
-class FakeSchedd:
-    """Minimal fake HTCondor schedd that returns a submit result."""
-
-    def submit(self, submit_description):
-        return FakeSubmitResult()
+from conftest import create_mock_submit_executor, mock_htcondor_submission
 
 
 class TestSubmittingAttributes:
-    """Tests for HTCondor raw and ClassAd submit attribute handling."""
-
     @pytest.fixture
     def mock_executor(self, tmp_path):
-        """Create a mock executor with minimal setup"""
-        executor = create_mock_executor()
-        executor.jobDir = str(tmp_path / "jobs")
-        executor.workflow = Mock()
-        executor.workflow.storage_settings.shared_fs_usage = False
-        executor.workflow.executor_settings = Mock()
-        executor.workflow.executor_settings.output_destination = None
-        executor.envvars = Mock(return_value={})
-        executor.report_job_submission = Mock()
-        executor._unified_log_file = str(tmp_path / "snakemake-rules.log")
-        # Bind real method under test + helper used by run_job
-        executor.run_job = Executor.run_job.__get__(executor, Executor)
-        executor._set_resources = Executor._set_resources.__get__(executor, Executor)
-
-        # Stub unrelated heavy pieces
-        executor._get_exec_args_and_transfer_files = Mock(
-            return_value=("python", "-m snakemake --cores 1", [], [], [])
-        )
-        executor._handle_explicit_unit_resources = Mock()
-        executor._log_resource_requests = Mock()
-        return executor
+        return create_mock_submit_executor(tmp_path)
 
     def test_run_job_applies_htcondor_submit_raw_attributes(self, mock_executor):
         """Test that htcondor_submit_* resources are copied into the submit dict."""
         captured_submit_dict = {}
-        patcher_submit = patch.object(
-            plugin.htcondor, "Submit", make_fake_submit(captured_submit_dict)
-        )
-        patcher_schedd = patch.object(plugin.htcondor, "Schedd", FakeSchedd)
-        patcher_submit.start()
-        patcher_schedd.start()
-
-        try:
+        with mock_htcondor_submission(captured_submit_dict):
             job = Mock()
             job.name = "rule_a"
             job.jobid = 7
@@ -101,27 +44,16 @@ class TestSubmittingAttributes:
 
             mock_executor.run_job(job)
 
-            assert captured_submit_dict["output_destination"] == '"/mnt/gdrive/outputs"'
-            assert captured_submit_dict["MY.SendCredential"] is True
-            assert captured_submit_dict["priority"] == 5
-            assert captured_submit_dict["nice_user"] is True
-            assert captured_submit_dict["batch_name"] == "rule_a-7"
-        finally:
-            patcher_submit.stop()
-            patcher_schedd.stop()
+        assert captured_submit_dict["output_destination"] == '"/mnt/gdrive/outputs"'
+        assert captured_submit_dict["MY.SendCredential"] is True
+        assert captured_submit_dict["priority"] == 5
+        assert captured_submit_dict["nice_user"] is True
+        assert captured_submit_dict["batch_name"] == "rule_a-7"
 
     def test_run_job_applies_classad_attributes(self, mock_executor):
         """Test that classad_* resources are copied into the submit dict."""
         captured_submit_dict = {}
-
-        patcher_submit = patch.object(
-            plugin.htcondor, "Submit", make_fake_submit(captured_submit_dict)
-        )
-        patcher_schedd = patch.object(plugin.htcondor, "Schedd", FakeSchedd)
-        patcher_submit.start()
-        patcher_schedd.start()
-
-        try:
+        with mock_htcondor_submission(captured_submit_dict):
             job = Mock()
             job.name = "rule_b"
             job.jobid = 8
@@ -134,25 +66,15 @@ class TestSubmittingAttributes:
 
             mock_executor.run_job(job)
 
-            assert captured_submit_dict["+MyDataSource"] == '"https://example.com/data"'
-            assert captured_submit_dict["+nice_user"] is True
-            assert captured_submit_dict["+priority"] == 5
-            assert captured_submit_dict["batch_name"] == "rule_b-8"
-        finally:
-            patcher_submit.stop()
-            patcher_schedd.stop()
+        assert captured_submit_dict["+MyDataSource"] == '"https://example.com/data"'
+        assert captured_submit_dict["+nice_user"] is True
+        assert captured_submit_dict["+priority"] == 5
+        assert captured_submit_dict["batch_name"] == "rule_b-8"
 
     def test_run_job_applies_classad_and_htcondor_submit_together(self, mock_executor):
         """Test that classad_* and htcondor_submit_* resources can coexist."""
         captured_submit_dict = {}
-        patcher_submit = patch.object(
-            plugin.htcondor, "Submit", make_fake_submit(captured_submit_dict)
-        )
-        patcher_schedd = patch.object(plugin.htcondor, "Schedd", FakeSchedd)
-        patcher_submit.start()
-        patcher_schedd.start()
-
-        try:
+        with mock_htcondor_submission(captured_submit_dict):
             job = Mock()
             job.name = "rule_c"
             job.jobid = 9
@@ -166,50 +88,36 @@ class TestSubmittingAttributes:
 
             mock_executor.run_job(job)
 
-            assert captured_submit_dict["+MyDataSource"] == '"https://example.com/data"'
-            assert captured_submit_dict["+priority"] == 5
-            assert captured_submit_dict["nice_user"] is True
-            assert captured_submit_dict["MY.SendCredential"] is False
-            assert captured_submit_dict["batch_name"] == "rule_c-9"
-        finally:
-            patcher_submit.stop()
-            patcher_schedd.stop()
+        assert captured_submit_dict["+MyDataSource"] == '"https://example.com/data"'
+        assert captured_submit_dict["+priority"] == 5
+        assert captured_submit_dict["nice_user"] is True
+        assert captured_submit_dict["MY.SendCredential"] is False
+        assert captured_submit_dict["batch_name"] == "rule_c-9"
 
-    def test_run_job_passes_through_list_and_dict_values(self, mock_executor):
-        """Lists and dicts (non-string types) are passed through unchanged."""
-        # Note: the production code currently passes non-string values
-        # (including lists and dicts) through unchanged into the submit
-        # description.
-        # We can implement stricter validation or serialization methods if required.
+    def test_same_resources_behaviors(self, mock_executor):
+        """Raw htcondor_submit_* values should NOT override plugin-generated submit keys."""
         captured_submit_dict = {}
-        patcher_submit = patch.object(
-            plugin.htcondor, "Submit", make_fake_submit(captured_submit_dict)
-        )
-        patcher_schedd = patch.object(plugin.htcondor, "Schedd", FakeSchedd)
-        patcher_submit.start()
-        patcher_schedd.start()
 
-        try:
+        # Ensure the executor generates a transfer_input_files entry
+        mock_executor._get_exec_args_and_transfer_files.return_value = (
+            "python",
+            "-m snakemake --cores 1",
+            ["htcondor.txt"],
+            [],
+            [],
+        )
+        with mock_htcondor_submission(captured_submit_dict):
             job = Mock()
             job.name = "rule_d"
-            job.jobid = 10
+            job.jobid = 9
             job.threads = 1
             job.resources = {
-                # htcondor_submit_ keys
-                "htcondor_submit_tags": ["a", "b"],
-                "htcondor_submit_metadata": {"k": "v"},
-                # classad_ keys
-                "classad_ListAttr": [1, 2, 3],
-                "classad_MapAttr": {"x": True},
+                # In real usage, paths are not quoted; this test uses a quoted string for simplicity
+                "htcondor_submit_transfer_input_files": "htcondor_submit.txt",
+                "htcondor_submit_request_memory": 1024,
+                "request_memory": 512,
             }
-
             mock_executor.run_job(job)
 
-            assert captured_submit_dict["tags"] == ["a", "b"]
-            assert captured_submit_dict["metadata"] == {"k": "v"}
-            assert captured_submit_dict["+ListAttr"] == [1, 2, 3]
-            assert captured_submit_dict["+MapAttr"] == {"x": True}
-            assert captured_submit_dict["batch_name"] == "rule_d-10"
-        finally:
-            patcher_submit.stop()
-            patcher_schedd.stop()
+        assert captured_submit_dict["transfer_input_files"] == "htcondor.txt"
+        assert captured_submit_dict["request_memory"] == 512


### PR DESCRIPTION
# Summary 
Currently, the executor only accepts a number of attributes as specified in `README.md`. This updates allow users to submit raw and site-specific HTCondor attributes through the executor via: `htcondor_submit_*` prefix. For example:
- `htcondor_submit_output_destination: <url>` becomes `output_destination: <url>`
- `htcondor_submit_MY.SendCredential: true` becomes `MY.SendCredential: True`
This PR also contains an integration test file where I tested both `htcondor_submit_*` and `classad_*`, and document updates with this new feature.

# Constraints/Notes
- The naming of this new feature is suggested by user in this issue #45.
- I am able to run and see that it works with raw attributes such as `priority` and `nice-user` through checking `submit_dict` and ran `condor_q -long <jobid>`. However, I am not sure how to test specific attributes that this user specified in issue #45. A confirmation that the fix works would be much appreciated after this PR gets approved.
- Regarding the data types for the raw attributes, I have not implemented any validation or serialization at the moment. This also applies to `classad_`. Therefore, users need to validate and double-check if they would like to use more complex datatypes such as list and dictionary. I can attempt adding one method to do that as well although I'm not sure whether I should reject complex data types or allow certain types.

Related Issue #45 