### PR TITLE
Filter job args for AP-specific paths

### DIFF
--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -16,7 +16,7 @@ from snakemake_interface_common.exceptions import WorkflowError  # noqa
 import htcondor2 as htcondor
 from htcondor2 import JobEventLog, JobEventType
 import traceback
-from os.path import join, isabs, relpath, normpath, exists
+from os.path import join, isabs, relpath, normpath, exists, isdir
 from os import makedirs, sep
 import re
 import sys
@@ -901,6 +901,81 @@ class Executor(RemoteExecutor):
         self.logger.debug(f"Config files to transfer: {config_paths_for_transfer}")
         return job_args, config_paths_for_transfer
 
+    def _strip_ap_local_path_args(self, job_args: str) -> str:
+        """
+        Drop absolute path arguments that resolve on the Access Point but are not
+        on a filesystem shared with the Execution Point.
+
+        Snakemake renders the spawned EP command on the AP and forwards several
+        location settings as absolute AP paths (e.g. ``--apptainer-prefix``, filled
+        from the inherited ``APPTAINER_CACHEDIR``, plus ``--conda-prefix``,
+        ``--shadow-prefix``, ``--directory``); those paths don't exist on the EP
+        and break the invocation. Rather than special-casing each setting, every
+        ``--flag <value>`` is judged purely by what the value is:
+
+        * not absolute, or under a configured shared-fs prefix -> reachable on the
+          EP (relative paths resolve under the job scratch dir; shared paths are
+          mounted on both) -> keep;
+        * does not resolve on the AP -> something the user expects elsewhere (baked
+          into their container, on CVMFS, node-local) -> keep;
+        * an AP-local directory, not shared -> a cache/scratch/workdir location ->
+          drop, so the EP falls back to its own default;
+        * an AP-local file, not shared -> unexpected here (content is passed as a
+          relative path or transferred separately) -> keep, but warn so a new leak
+          surfaces instead of breaking silently.
+
+        Only single-valued flags are considered, so list arguments (e.g.
+        ``--configfiles a b``) are never partially rewritten. Runs on the AP, and
+        only without a (fully) shared filesystem (the caller skips it otherwise).
+
+        Args:
+            job_args: The spawned-job argument string (prefix-stripped, sanitized).
+
+        Returns:
+            ``job_args`` with AP-local directory arguments removed.
+        """
+        tokens = job_args.split()
+        kept = []
+        i = 0
+        n = len(tokens)
+        while i < n:
+            flag = tokens[i]
+            value = tokens[i + 1] if i + 1 < n else None
+            after = tokens[i + 2] if i + 2 < n else None
+            # "--flag VALUE" where VALUE is not itself a flag and is followed by a
+            # flag or the end of the command. This guard means a list argument is
+            # never partially rewritten.
+            single_valued = (
+                flag.startswith("--")
+                and value is not None
+                and not value.startswith("--")
+                and (after is None or after.startswith("--"))
+            )
+            if single_valued and isabs(value):
+                if is_shared_fs(value, self.shared_fs_prefixes):
+                    pass  # mounted on both AP and EP -> reachable, keep
+                elif isdir(value):
+                    self.logger.debug(
+                        f"Dropping {flag} '{value}' from the spawned command: an "
+                        "Access-Point-local directory not on a shared filesystem, "
+                        "so it will not exist on the Execution Point. The Execution "
+                        "Point will use its own default location."
+                    )
+                    i += 2
+                    continue
+                elif exists(value):
+                    self.logger.warning(
+                        f"Argument {flag} '{value}' is an absolute Access-Point "
+                        "path not on a shared filesystem; it will not exist on the "
+                        "Execution Point. Leaving it in place; declare it via "
+                        "--htcondor-shared-fs-prefixes if it is in fact shared."
+                    )
+                # else: does not resolve on the AP (CVMFS, container-baked,
+                # node-local, or to be created on the EP) -> keep untouched.
+            kept.append(flag)
+            i += 1
+        return " ".join(kept)
+
     def _get_base_exec_and_args(self, job: JobExecutorInterface) -> tuple[str, str]:
         """
         Get the base executable and arguments for the HTCondor job.
@@ -1044,6 +1119,11 @@ class Executor(RemoteExecutor):
 
         # Add config files to the transfer input list
         transfer_input_files.extend(config_paths)
+
+        # Drop absolute path args that resolve on the AP but aren't on a shared
+        # filesystem: they are AP-local and won't exist on the EP. Paths not on the
+        # AP (CVMFS, container-baked, node-local) pass through unchanged.
+        job_args = self._strip_ap_local_path_args(job_args)
 
         self.logger.debug(f"Final arguments: {job_args}")
         self.logger.debug(

--- a/tests/test_config_file_paths.py
+++ b/tests/test_config_file_paths.py
@@ -494,6 +494,9 @@ class TestFilesystemModes:
         self.executor._sanitize_job_args = Executor._sanitize_job_args.__get__(
             self.executor, Executor
         )
+        self.executor._strip_ap_local_path_args = (
+            Executor._strip_ap_local_path_args.__get__(self.executor, Executor)
+        )
 
     def test_mode1_full_shared_fs_no_transfer(self):
         """

--- a/tests/test_no_shared_fs_hardening.py
+++ b/tests/test_no_shared_fs_hardening.py
@@ -429,3 +429,135 @@ class TestOutputRemaps:
 
         assert "logs/run.log" in transfer_output
         assert any("logs/run.log" in r for r in remaps)
+
+
+# ---------------------------------------------------------------------------
+# 4. AP-local absolute path scrubbing (reachability-based)
+# ---------------------------------------------------------------------------
+
+
+def _make_scrub_executor(shared_prefixes=None):
+    """Mock Executor with _strip_ap_local_path_args bound."""
+    executor = Mock(spec=Executor)
+    executor.logger = Mock()
+    executor.shared_fs_prefixes = shared_prefixes or []
+    executor._strip_ap_local_path_args = Executor._strip_ap_local_path_args.__get__(
+        executor, Executor
+    )
+    return executor
+
+
+class TestStripApLocalPathArgs:
+    """Absolute path args that resolve on the AP but aren't shared are dropped
+    (directories) or warned about (files); paths that don't resolve on the AP
+    (CVMFS / container-baked / node-local), shared paths, and relative paths all
+    pass through untouched."""
+
+    def test_ap_local_directory_dropped(self, tmp_path):
+        """The reported bug: an absolute AP directory (e.g. a leaked
+        APPTAINER_CACHEDIR) is removed when it is not on a shared filesystem."""
+        cache = tmp_path / "apptainer_cache"
+        cache.mkdir()
+        ex = _make_scrub_executor()
+        args = f"--snakefile Snakefile --apptainer-prefix {cache} --notemp"
+        out = ex._strip_ap_local_path_args(args)
+
+        assert "--apptainer-prefix" not in out
+        assert str(cache) not in out
+        assert "--snakefile Snakefile" in out
+        assert "--notemp" in out
+
+    def test_nonexistent_path_kept(self, tmp_path):
+        """A path that does not resolve on the AP (CVMFS / container-baked /
+        node-local) must pass through untouched."""
+        missing = tmp_path / "cvmfs_like" / "images"  # never created
+        ex = _make_scrub_executor()
+        args = f"--apptainer-prefix {missing} --notemp"
+        out = ex._strip_ap_local_path_args(args)
+
+        assert f"--apptainer-prefix {missing}" in out
+
+    def test_shared_prefix_directory_kept(self, tmp_path):
+        """An AP-resident directory under a declared shared-fs prefix is reachable
+        on the EP and must be kept."""
+        shared = tmp_path / "staging"
+        cache = shared / "cache"
+        cache.mkdir(parents=True)
+        ex = _make_scrub_executor(shared_prefixes=[str(shared) + "/"])
+        args = f"--apptainer-prefix {cache} --notemp"
+        out = ex._strip_ap_local_path_args(args)
+
+        assert f"--apptainer-prefix {cache}" in out
+
+    def test_relative_path_kept(self):
+        """Relative prefixes resolve under the EP scratch dir and are kept."""
+        ex = _make_scrub_executor()
+        args = "--apptainer-prefix .snakemake/singularity --notemp"
+        out = ex._strip_ap_local_path_args(args)
+
+        assert "--apptainer-prefix .snakemake/singularity" in out
+
+    def test_ap_local_file_warned_but_kept(self, tmp_path):
+        """An absolute AP *file* (unexpected here) is surfaced via a warning but
+        left in place rather than silently dropped."""
+        f = tmp_path / "ref.yaml"
+        f.write_text("x: 1\n")
+        ex = _make_scrub_executor()
+        args = f"--some-file {f} --notemp"
+        out = ex._strip_ap_local_path_args(args)
+
+        assert f"--some-file {f}" in out
+        assert ex.logger.warning.called
+        warning_text = " ".join(str(c) for c in ex.logger.warning.call_args_list)
+        assert str(f) in warning_text
+
+    def test_multiple_ap_local_dirs_dropped(self, tmp_path):
+        """Several AP-local directory args are scrubbed in a single pass."""
+        d1 = tmp_path / "apcache"
+        d1.mkdir()
+        d2 = tmp_path / "condacache"
+        d2.mkdir()
+        ex = _make_scrub_executor()
+        args = f"--apptainer-prefix {d1} --conda-prefix {d2} --notemp"
+        out = ex._strip_ap_local_path_args(args)
+
+        assert "--apptainer-prefix" not in out
+        assert "--conda-prefix" not in out
+        assert "--notemp" in out
+
+    def test_list_arg_not_partially_rewritten(self, tmp_path):
+        """A multi-valued flag is never touched, so the command can't be corrupted
+        even when its values are AP-local directories."""
+        d1 = tmp_path / "a"
+        d1.mkdir()
+        d2 = tmp_path / "b"
+        d2.mkdir()
+        ex = _make_scrub_executor()
+        args = f"--configfiles {d1} {d2} --notemp"
+        out = ex._strip_ap_local_path_args(args)
+
+        assert "--configfiles" in out
+        assert str(d1) in out
+        assert str(d2) in out
+
+    def test_boolean_flags_and_scalar_values_preserved(self, tmp_path):
+        """Boolean flags and ordinary scalar values survive; only the AP-local
+        directory arg is removed."""
+        cache = tmp_path / "cache"
+        cache.mkdir()
+        ex = _make_scrub_executor()
+        args = f"--force --cores all --apptainer-prefix {cache} --notemp"
+        out = ex._strip_ap_local_path_args(args)
+
+        assert "--force" in out
+        assert "--cores all" in out
+        assert "--apptainer-prefix" not in out
+        assert "--notemp" in out
+
+    def test_no_absolute_args_unchanged(self):
+        """A command with no absolute path args is returned verbatim."""
+        ex = _make_scrub_executor()
+        args = "--snakefile Snakefile --cores all --notemp"
+        out = ex._strip_ap_local_path_args(args)
+
+        assert out == args


### PR DESCRIPTION
On a cluster with no shared filesystem (e.g. CHTC), the management Snakemake
process can hand an Execution Point job an absolute path that only exists on the
Access Point. The recurring offender is `--apptainer-prefix`: Snakemake auto-fills
it from the inherited `APPTAINER_CACHEDIR` and forwards it to every spawned job, so
an AP-local cache path leaks into an EP context where it doesn't exist and the
remote invocation fails. The user hasn't misconfigured anything — and the same
shape of leak can affect other location settings (conda/shadow prefixes,
`--directory`), because Snakemake renders the command on the AP and is inconsistent
about which paths it makes safe for the remote side.

This patch fixes the problem by iterating through the snakemake-constructed
arguments and trying to determine whether any path being provided there
is one that will not exist on the EP.